### PR TITLE
AI 에이전트용 설치 가이드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,31 @@
 	`sudo python3 print_sam4s.py`
 
 ## 설치방법
-### Raspberry pi(cups) + Bixolon SRP-330II 
+
+### AI 에이전트를 이용한 자동 설치 (권장)
+
+Claude Code와 같은 AI 에이전트가 자동으로 설치를 수행할 수 있습니다.
+
+**사전 준비 (사람이 수행):**
+1. Raspberry Pi Imager로 **Raspbian 64-bit Lite** 이미지 굽기
+2. 첫 부팅 시 WiFi, SSH 설정
+3. Bixolon SRP-330II 프린터 USB 연결
+4. 정격 5V 2A 이상 파워 아답터 사용 (Adaptive Power 금지)
+
+**AI 에이전트 실행:**
+1. SSH로 라즈베리파이 접속
+2. 저장소 클론:
+   ```bash
+   git clone https://github.com/AntonSangho/moya-worklog.git
+   ```
+3. AI 에이전트(Claude Code 등)가 SSH로 접속
+4. AI 에이전트에게 `install.md` 파일을 따라 설치 요청
+
+자세한 내용은 [install.md](./install.md) 참고
+
+---
+
+### Raspberry pi(cups) + Bixolon SRP-330II (수동 설치) 
 1. 라즈베리파이 imge 준비 : Raspbian 32-bit Desktop ver (2021-05-07)
 2. 라즈베리파이 ssh, spi enable 
 3. 원격 다운로드  

--- a/install.md
+++ b/install.md
@@ -72,6 +72,18 @@ git submodule update --init --recursive
 
 ### Step 3: Python 의존성 설치
 
+> **주의:** `requirements.txt`의 고정 버전이 Python 3.13과 호환되지 않을 수 있습니다.
+> Debian 13 (trixie) 이상에서는 아래 방법으로 설치하세요.
+
+```bash
+# 핵심 패키지 설치 (버전 고정 없이)
+sudo pip3 install --break-system-packages pillow python-escpos pyusb qrcode pyserial
+
+# Debian 13 (trixie)에서 GPIO 호환성을 위해 rpi-lgpio 설치
+sudo pip3 install --break-system-packages rpi-lgpio
+```
+
+기존 방식 (Python 3.11 이하):
 ```bash
 cd ~/moya-worklog
 pip3 install -r requirements.txt
@@ -218,6 +230,50 @@ journalctl -u moya-worklog -n 50
 
 # 수동 실행으로 에러 확인
 sudo python3 /home/pi/moya-worklog/print_Bixolon.py
+```
+
+---
+
+### Debian 13 (trixie) / Python 3.13 관련 이슈
+
+**1. Pillow 빌드 실패 (KeyError: '__version__')**
+
+증상:
+```
+KeyError: '__version__'
+Getting requirements to build wheel: finished with status 'error'
+```
+
+원인: `requirements.txt`의 `Pillow==9.1.1`이 Python 3.13과 호환되지 않음
+
+해결:
+```bash
+sudo pip3 install --break-system-packages pillow
+```
+
+**2. ModuleNotFoundError: No module named 'escpos'**
+
+증상: systemd 서비스 시작 시 모듈을 찾지 못함
+
+원인: `pip3 install`이 사용자 경로(`~/.local`)에만 설치되어 root로 실행되는 systemd에서 접근 불가
+
+해결:
+```bash
+sudo pip3 install --break-system-packages pillow python-escpos pyusb qrcode pyserial
+```
+
+**3. RuntimeError: Failed to add edge detection**
+
+증상:
+```
+RuntimeError: Failed to add edge detection
+```
+
+원인: Debian 13에서 기존 RPi.GPIO의 edge detection이 작동하지 않음
+
+해결:
+```bash
+sudo pip3 install --break-system-packages rpi-lgpio
 ```
 
 ### 유용한 명령어

--- a/install.md
+++ b/install.md
@@ -198,12 +198,15 @@ ps aux | grep print_Bixolon
 
 ### GPIO 핀 연결
 
-| 기능 | GPIO (BCM) | 물리 핀 |
-|------|------------|---------|
-| Print Button | 21 | 40 |
-| Print Button LED | 20 | 38 |
-| Reset Button | 3 | 5 |
-| Power LED | 6 | 31 |
+**버튼은 GPIO 2 또는 21 중 하나를 사용할 수 있습니다.**
+
+| 기능 | GPIO (BCM) | 물리 핀 | 비고 |
+|------|------------|---------|------|
+| Print Button (옵션 1) | 2 | 3 | |
+| Print Button (옵션 2) | 21 | 40 | |
+| Print Button LED | 20 | 38 | |
+| Reset Button | 3 | 5 | |
+| Power LED | 6 | 31 | |
 
 ### 트러블슈팅
 

--- a/install.md
+++ b/install.md
@@ -1,0 +1,276 @@
+# Moya Worklog 라즈베리파이 설치 가이드
+
+이 문서는 AI agent가 자동으로 실행할 수 있도록 작성된 설치 가이드입니다.
+
+---
+
+## 사전 준비물
+
+### 하드웨어
+- [ ] 라즈베리파이 (Raspberry Pi 4 권장)
+- [ ] MicroSD 카드 (16GB 이상)
+- [ ] 프린터: Bixolon SRP-330II (USB 연결)
+- [ ] 파워 아답터: **정격 5V 2A 이상** (Adaptive Power 사용 금지)
+- [ ] 모니터 (HDMI 연결)
+- [ ] USB 키보드
+
+### 소프트웨어
+- Raspberry Pi Imager (SD 카드 이미징용)
+- Raspbian OS 64-bit Lite
+
+---
+
+## 1단계: SD 카드 이미지 굽기
+
+1. [Raspberry Pi Imager](https://www.raspberrypi.com/software/) 다운로드 및 설치
+2. SD 카드를 컴퓨터에 삽입
+3. Raspberry Pi Imager 실행
+4. OS 선택: **Raspberry Pi OS (64-bit) Lite**
+   - `Raspberry Pi OS (other)` > `Raspberry Pi OS Lite (64-bit)` 선택
+5. 저장소 선택: 삽입한 SD 카드 선택
+6. **설정 아이콘(톱니바퀴)** 클릭하여 사전 설정:
+   - 호스트명: `pi`
+   - SSH 활성화: 체크
+   - 사용자 이름: `pi`
+   - 비밀번호: 원하는 비밀번호 설정
+   - WiFi 설정: 노트북과 동일한 네트워크 SSID 및 비밀번호 입력
+   - 로캘 설정: Asia/Seoul
+7. **쓰기** 버튼 클릭하여 이미징 시작
+8. 완료 후 SD 카드 안전하게 제거
+
+---
+
+## 2단계: 하드웨어 조립
+
+1. SD 카드를 라즈베리파이에 삽입
+2. 모니터를 HDMI로 연결
+3. USB 키보드 연결
+4. Bixolon SRP-330II 프린터를 USB로 연결
+5. **마지막에** 파워 아답터 연결 (5V 2A 정격)
+
+---
+
+## 3단계: 첫 부팅 및 기본 설정
+
+### 부팅 확인
+1. 전원 연결 후 부팅 대기 (약 1-2분)
+2. 로그인 프롬프트가 나타나면:
+   - 사용자: `pi`
+   - 비밀번호: (Imager에서 설정한 비밀번호)
+
+### 네트워크 확인
+```bash
+# IP 주소 확인
+ip addr show wlan0
+
+# 인터넷 연결 테스트
+ping -c 3 google.com
+```
+
+### SSH 활성화 확인
+```bash
+sudo systemctl status ssh
+# Active: active (running) 확인
+```
+
+만약 SSH가 비활성화되어 있다면:
+```bash
+sudo systemctl enable ssh
+sudo systemctl start ssh
+```
+
+---
+
+## 4단계: 시스템 업데이트
+
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+---
+
+## 5단계: 필수 패키지 설치
+
+```bash
+# Python 및 개발 도구
+sudo apt install -y python3-dev python3-pip python3-venv git
+
+# CUPS 프린팅 시스템
+sudo apt install -y cups libcups2-dev
+
+# USB 라이브러리
+sudo apt install -y libusb-1.0-0-dev
+
+# GPIO 라이브러리
+sudo apt install -y python3-gpiozero python3-rpi.gpio
+```
+
+---
+
+## 6단계: 프로젝트 클론
+
+```bash
+cd ~
+git clone https://github.com/[저장소경로]/moya-worklog.git
+cd moya-worklog
+git submodule update --init --recursive
+```
+
+---
+
+## 7단계: Python 의존성 설치
+
+```bash
+cd ~/moya-worklog
+pip3 install -r requirements.txt
+```
+
+---
+
+## 8단계: Bixolon 프린터 드라이버 설치
+
+```bash
+cd ~/moya-worklog/Driver
+
+# 드라이버 압축 해제
+unzip Software_BixolonCupsDrv_RaspberryPI_v1.3.5.1.zip
+
+# 드라이버 설치 (압축 해제된 폴더로 이동 후)
+cd [압축해제폴더]
+sudo ./install.sh
+```
+
+### CUPS 프린터 추가
+```bash
+# CUPS 웹 인터페이스 활성화
+sudo usermod -aG lpadmin pi
+sudo cupsctl --remote-any
+
+# 프린터 확인
+lpinfo -v | grep usb
+```
+
+웹브라우저에서 `http://[라즈베리파이IP]:631` 접속하여 프린터 추가
+
+---
+
+## 9단계: USB 프린터 권한 설정
+
+```bash
+# udev 규칙 추가 (Bixolon SRP-330II)
+echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="1504", ATTR{idProduct}=="006e", MODE="0666"' | sudo tee /etc/udev/rules.d/99-bixolon.rules
+
+# udev 재시작
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+---
+
+## 10단계: 테스트 실행
+
+```bash
+cd ~/moya-worklog
+
+# 프린터 테스트
+sudo python3 print_Bixolon.py
+```
+
+GPIO 21번 핀에 연결된 버튼을 누르면 이미지가 출력됩니다.
+
+---
+
+## 11단계: 자동 시작 설정
+
+### 방법 1: rc.local 사용
+```bash
+sudo nano /etc/rc.local
+```
+
+`exit 0` 전에 다음 줄 추가:
+```bash
+python3 /home/pi/moya-worklog/print_Bixolon.py &
+```
+
+### 방법 2: systemd 서비스 생성 (권장)
+```bash
+sudo nano /etc/systemd/system/moya-worklog.service
+```
+
+내용:
+```ini
+[Unit]
+Description=Moya Worklog Printer Service
+After=multi-user.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/home/pi/moya-worklog
+ExecStart=/usr/bin/python3 /home/pi/moya-worklog/print_Bixolon.py
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+서비스 활성화:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable moya-worklog.service
+sudo systemctl start moya-worklog.service
+```
+
+---
+
+## 12단계: GPIO 연결 (하드웨어)
+
+| 기능 | GPIO (BCM) | 물리 핀 |
+|------|------------|---------|
+| Print Button | 21 | 40 |
+| Print Button LED | 20 | 38 |
+| Reset Button | 3 | 5 |
+| Power LED | 6 | 31 |
+
+버튼은 **Pull-Down** 저항 설정으로 동작합니다.
+
+---
+
+## 문제 해결
+
+### 프린터가 인식되지 않음
+```bash
+# USB 장치 확인
+lsusb | grep -i bixolon
+
+# 예상 출력: Bus 001 Device 00X: ID 1504:006e
+```
+
+### GPIO 권한 오류
+```bash
+sudo usermod -aG gpio pi
+# 재부팅 후 적용
+```
+
+### 전원 불안정으로 인한 오작동
+- 정격 5V 2A 이상의 파워 아답터 사용
+- Adaptive Power (USB PD) 사용 금지
+- USB 허브를 통한 연결 지양
+
+---
+
+## 요약 체크리스트
+
+- [ ] SD 카드 이미징 완료 (Raspbian 64-bit Lite)
+- [ ] 첫 부팅 및 로그인 성공
+- [ ] WiFi 연결 확인
+- [ ] SSH 활성화 확인
+- [ ] 시스템 업데이트 완료
+- [ ] 필수 패키지 설치 완료
+- [ ] 프로젝트 클론 완료
+- [ ] Python 의존성 설치 완료
+- [ ] Bixolon 드라이버 설치 완료
+- [ ] USB 권한 설정 완료
+- [ ] 테스트 출력 성공
+- [ ] 자동 시작 설정 완료

--- a/install.md
+++ b/install.md
@@ -1,204 +1,147 @@
-# Moya Worklog 라즈베리파이 설치 가이드
+# Moya Worklog 설치 가이드
 
-이 문서는 AI agent가 자동으로 실행할 수 있도록 작성된 설치 가이드입니다.
-
----
-
-## 사전 준비물
-
-### 하드웨어
-- [ ] 라즈베리파이 (Raspberry Pi 4 권장)
-- [ ] MicroSD 카드 (16GB 이상)
-- [ ] 프린터: Bixolon SRP-330II (USB 연결)
-- [ ] 파워 아답터: **정격 5V 2A 이상** (Adaptive Power 사용 금지)
-- [ ] 모니터 (HDMI 연결)
-- [ ] USB 키보드
-
-### 소프트웨어
-- Raspberry Pi Imager (SD 카드 이미징용)
-- Raspbian OS 64-bit Lite
+라즈베리파이에 moya-worklog를 설치하는 AI 에이전트라면, 아래 단계를 순서대로 따라주세요.
 
 ---
 
-## 1단계: SD 카드 이미지 굽기
+## 사전 조건 (사람이 완료해야 함)
 
-1. [Raspberry Pi Imager](https://www.raspberrypi.com/software/) 다운로드 및 설치
-2. SD 카드를 컴퓨터에 삽입
-3. Raspberry Pi Imager 실행
-4. OS 선택: **Raspberry Pi OS (64-bit) Lite**
-   - `Raspberry Pi OS (other)` > `Raspberry Pi OS Lite (64-bit)` 선택
-5. 저장소 선택: 삽입한 SD 카드 선택
-6. **설정 아이콘(톱니바퀴)** 클릭하여 사전 설정:
-   - 호스트명: `pi`
-   - SSH 활성화: 체크
-   - 사용자 이름: `pi`
-   - 비밀번호: 원하는 비밀번호 설정
-   - WiFi 설정: 노트북과 동일한 네트워크 SSID 및 비밀번호 입력
-   - 로캘 설정: Asia/Seoul
-7. **쓰기** 버튼 클릭하여 이미징 시작
-8. 완료 후 SD 카드 안전하게 제거
+이 가이드를 실행하기 전에 아래 항목이 완료되어 있어야 합니다:
+
+- [ ] 라즈베리파이에 Raspbian 64-bit Lite 설치 완료
+- [ ] WiFi 연결 완료 (노트북과 같은 네트워크)
+- [ ] SSH 활성화 완료
+- [ ] 호스트명: `pi`
+- [ ] Bixolon SRP-330II 프린터 USB 연결
+- [ ] 정격 5V 2A 이상 파워 아답터 사용 (Adaptive Power 금지)
 
 ---
 
-## 2단계: 하드웨어 조립
+## Step 0: 사전 요구사항 확인
 
-1. SD 카드를 라즈베리파이에 삽입
-2. 모니터를 HDMI로 연결
-3. USB 키보드 연결
-4. Bixolon SRP-330II 프린터를 USB로 연결
-5. **마지막에** 파워 아답터 연결 (5V 2A 정격)
+시스템 정보 및 네트워크 상태를 확인하세요:
 
----
-
-## 3단계: 첫 부팅 및 기본 설정
-
-### 부팅 확인
-1. 전원 연결 후 부팅 대기 (약 1-2분)
-2. 로그인 프롬프트가 나타나면:
-   - 사용자: `pi`
-   - 비밀번호: (Imager에서 설정한 비밀번호)
-
-### 네트워크 확인
 ```bash
-# IP 주소 확인
-ip addr show wlan0
+# OS 버전 확인 (64-bit 확인)
+uname -m
+cat /etc/os-release | head -5
 
-# 인터넷 연결 테스트
-ping -c 3 google.com
+# 네트워크 연결 확인
+ping -c 2 google.com
+
+# USB 프린터 연결 확인 (Bixolon SRP-330II: 1504:006e)
+lsusb | grep -i "1504:006e" || echo "WARNING: Bixolon 프린터가 연결되지 않음"
 ```
 
-### SSH 활성화 확인
-```bash
-sudo systemctl status ssh
-# Active: active (running) 확인
-```
-
-만약 SSH가 비활성화되어 있다면:
-```bash
-sudo systemctl enable ssh
-sudo systemctl start ssh
-```
-
----
-
-## 4단계: 시스템 업데이트
+### Step 1: 시스템 업데이트 및 필수 패키지 설치
 
 ```bash
 sudo apt update && sudo apt upgrade -y
-```
 
----
-
-## 5단계: 필수 패키지 설치
-
-```bash
 # Python 및 개발 도구
-sudo apt install -y python3-dev python3-pip python3-venv git
+sudo apt install -y python3-dev python3-pip python3-venv
 
 # CUPS 프린팅 시스템
 sudo apt install -y cups libcups2-dev
 
-# USB 라이브러리
-sudo apt install -y libusb-1.0-0-dev
+# USB 및 GPIO 라이브러리
+sudo apt install -y libusb-1.0-0-dev python3-gpiozero python3-rpi.gpio
 
-# GPIO 라이브러리
-sudo apt install -y python3-gpiozero python3-rpi.gpio
+# Git 확인
+if ! command -v git &> /dev/null; then
+  sudo apt install -y git
+fi
+git --version
 ```
 
----
-
-## 6단계: 프로젝트 클론
+### Step 2: 저장소 Clone
 
 ```bash
 cd ~
-git clone https://github.com/[저장소경로]/moya-worklog.git
+git clone https://github.com/user/moya-worklog.git
 cd moya-worklog
 git submodule update --init --recursive
 ```
 
----
+이미 clone된 저장소가 있다면 최신 상태로 업데이트하세요:
+```bash
+cd ~/moya-worklog
+git pull origin main
+git submodule update --init --recursive
+```
 
-## 7단계: Python 의존성 설치
+### Step 3: Python 의존성 설치
 
 ```bash
 cd ~/moya-worklog
 pip3 install -r requirements.txt
 ```
 
----
-
-## 8단계: Bixolon 프린터 드라이버 설치
+### Step 4: Bixolon 프린터 드라이버 설치
 
 ```bash
 cd ~/moya-worklog/Driver
 
 # 드라이버 압축 해제
-unzip Software_BixolonCupsDrv_RaspberryPI_v1.3.5.1.zip
+unzip -o Software_BixolonCupsDrv_RaspberryPI_v1.3.5.1.zip
 
-# 드라이버 설치 (압축 해제된 폴더로 이동 후)
-cd [압축해제폴더]
+# 압축 해제된 폴더 확인 후 설치
+cd bixolon* || cd Bixolon* || cd BIXOLON*
 sudo ./install.sh
 ```
 
-### CUPS 프린터 추가
-```bash
-# CUPS 웹 인터페이스 활성화
-sudo usermod -aG lpadmin pi
-sudo cupsctl --remote-any
-
-# 프린터 확인
-lpinfo -v | grep usb
-```
-
-웹브라우저에서 `http://[라즈베리파이IP]:631` 접속하여 프린터 추가
-
----
-
-## 9단계: USB 프린터 권한 설정
+### Step 5: USB 프린터 권한 설정
 
 ```bash
-# udev 규칙 추가 (Bixolon SRP-330II)
+# udev 규칙 추가 (Bixolon SRP-330II: VID=1504, PID=006e)
 echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="1504", ATTR{idProduct}=="006e", MODE="0666"' | sudo tee /etc/udev/rules.d/99-bixolon.rules
 
 # udev 재시작
 sudo udevadm control --reload-rules
 sudo udevadm trigger
+
+# pi 사용자를 필요한 그룹에 추가
+sudo usermod -aG lpadmin,gpio pi
 ```
 
----
-
-## 10단계: 테스트 실행
+### Step 6: 설치 확인
 
 ```bash
 cd ~/moya-worklog
 
-# 프린터 테스트
-sudo python3 print_Bixolon.py
+# 프린터 연결 확인
+lsusb | grep "1504:006e"
+
+# Python 모듈 확인
+python3 -c "from escpos import printer; print('escpos OK')"
+python3 -c "import RPi.GPIO as GPIO; print('GPIO OK')"
+python3 -c "from PIL import Image; print('Pillow OK')"
+```
+
+모든 확인이 통과하면 설치 성공입니다.
+
+### Step 7: 테스트 실행
+
+```bash
+cd ~/moya-worklog
+sudo python3 print_Bixolon.py &
+
+# 3초 대기 후 프로세스 확인
+sleep 3
+ps aux | grep print_Bixolon
 ```
 
 GPIO 21번 핀에 연결된 버튼을 누르면 이미지가 출력됩니다.
-
----
-
-## 11단계: 자동 시작 설정
-
-### 방법 1: rc.local 사용
+테스트 후 프로세스 종료:
 ```bash
-sudo nano /etc/rc.local
+sudo pkill -f print_Bixolon.py
 ```
 
-`exit 0` 전에 다음 줄 추가:
-```bash
-python3 /home/pi/moya-worklog/print_Bixolon.py &
-```
+### Step 8: 자동 시작 설정 (systemd)
 
-### 방법 2: systemd 서비스 생성 (권장)
 ```bash
-sudo nano /etc/systemd/system/moya-worklog.service
-```
-
-내용:
-```ini
+# systemd 서비스 파일 생성
+sudo tee /etc/systemd/system/moya-worklog.service > /dev/null << 'EOF'
 [Unit]
 Description=Moya Worklog Printer Service
 After=multi-user.target
@@ -213,18 +156,35 @@ RestartSec=5
 
 [Install]
 WantedBy=multi-user.target
-```
+EOF
 
-서비스 활성화:
-```bash
+# 서비스 활성화 및 시작
 sudo systemctl daemon-reload
 sudo systemctl enable moya-worklog.service
 sudo systemctl start moya-worklog.service
 ```
 
+### Step 9: 최종 확인
+
+```bash
+# 서비스 상태 확인
+sudo systemctl status moya-worklog.service
+
+# 실행 중인지 확인
+ps aux | grep print_Bixolon
+```
+
+`Active: active (running)`이 출력되면 설치 성공입니다. 사용자에게 아래 정보를 안내하세요:
+
+- **서비스 상태 확인**: `sudo systemctl status moya-worklog`
+- **로그 확인**: `journalctl -u moya-worklog -f`
+- **재부팅 후 자동 시작됨**
+
 ---
 
-## 12단계: GPIO 연결 (하드웨어)
+## 참고 정보
+
+### GPIO 핀 연결
 
 | 기능 | GPIO (BCM) | 물리 핀 |
 |------|------------|---------|
@@ -233,44 +193,45 @@ sudo systemctl start moya-worklog.service
 | Reset Button | 3 | 5 |
 | Power LED | 6 | 31 |
 
-버튼은 **Pull-Down** 저항 설정으로 동작합니다.
+### 트러블슈팅
 
----
-
-## 문제 해결
-
-### 프린터가 인식되지 않음
+**프린터가 인식되지 않을 경우:**
 ```bash
-# USB 장치 확인
-lsusb | grep -i bixolon
-
-# 예상 출력: Bus 001 Device 00X: ID 1504:006e
+# USB 장치 재확인
+lsusb
+# 프린터 분리 후 재연결
+# udev 규칙 재적용
+sudo udevadm control --reload-rules && sudo udevadm trigger
 ```
 
-### GPIO 권한 오류
+**GPIO 권한 오류:**
 ```bash
 sudo usermod -aG gpio pi
-# 재부팅 후 적용
+# 재부팅 필요
+sudo reboot
 ```
 
-### 전원 불안정으로 인한 오작동
-- 정격 5V 2A 이상의 파워 아답터 사용
-- Adaptive Power (USB PD) 사용 금지
-- USB 허브를 통한 연결 지양
+**서비스가 시작되지 않을 경우:**
+```bash
+# 로그 확인
+journalctl -u moya-worklog -n 50
 
----
+# 수동 실행으로 에러 확인
+sudo python3 /home/pi/moya-worklog/print_Bixolon.py
+```
 
-## 요약 체크리스트
+### 유용한 명령어
 
-- [ ] SD 카드 이미징 완료 (Raspbian 64-bit Lite)
-- [ ] 첫 부팅 및 로그인 성공
-- [ ] WiFi 연결 확인
-- [ ] SSH 활성화 확인
-- [ ] 시스템 업데이트 완료
-- [ ] 필수 패키지 설치 완료
-- [ ] 프로젝트 클론 완료
-- [ ] Python 의존성 설치 완료
-- [ ] Bixolon 드라이버 설치 완료
-- [ ] USB 권한 설정 완료
-- [ ] 테스트 출력 성공
-- [ ] 자동 시작 설정 완료
+```bash
+# 서비스 중지
+sudo systemctl stop moya-worklog
+
+# 서비스 재시작
+sudo systemctl restart moya-worklog
+
+# 서비스 비활성화 (부팅 시 자동시작 안함)
+sudo systemctl disable moya-worklog
+
+# 실시간 로그
+journalctl -u moya-worklog -f
+```

--- a/print_Bixolon.py
+++ b/print_Bixolon.py
@@ -28,13 +28,21 @@ file4 = "/home/pi/moya-worklog/image/w4_2022.png"
 file5 = "/home/pi/moya-worklog/image/w5_2022.png"
 filelist = [file1, file2, file3, file4, file5]
 
-GPIO.setmode(GPIO.BCM)
-GPIO.setup(21, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
+# GPIO 핀 설정
+BUTTON_PINS = [2, 21]  # 두 GPIO 핀 모두 버튼으로 허용
+LED_PIN = 20
 
+GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)
-GPIO.setup(20, GPIO.OUT)
+
+# 버튼 핀 설정 (GPIO 2, 21 모두 지원)
+for pin in BUTTON_PINS:
+    GPIO.setup(pin, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
+
+# LED 핀 설정
+GPIO.setup(LED_PIN, GPIO.OUT)
 print("LED on")
-GPIO.output(20, GPIO.HIGH)
+GPIO.output(LED_PIN, GPIO.HIGH)
 time.sleep(1)
 count = 0
 
@@ -52,11 +60,15 @@ def print_test(channel):
     p.text(str(count) + "\n")
     p.cut()
 
-GPIO.add_event_detect(21, GPIO.RISING, callback=print_sam4s, bouncetime=2000)
+# 두 버튼 핀 모두 이벤트 감지
+for pin in BUTTON_PINS:
+    GPIO.add_event_detect(pin, GPIO.RISING, callback=print_sam4s, bouncetime=2000)
+
+print(f"버튼 GPIO {BUTTON_PINS} 대기 중...")
 
 try:
     while True:
         pass
 except KeyboardInterrupt:
-        GPIO.output(20, GPIO.LOW)
+        GPIO.output(LED_PIN, GPIO.LOW)
         GPIO.cleanup()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,25 +1,18 @@
-appdirs==1.4.4
-argcomplete==2.0.0
-certifi==2020.6.20
-chardet==4.0.0
-colorzero==1.1
-distro==1.5.0
-escpos==1.9
-future==0.18.2
-gpiozero==1.6.2
-idna==2.10
-Pillow==9.1.1
-pycups==2.0.1
-pyserial==3.5
-python-barcode==0.14.0
-python-escpos==2.2.0
-pyusb==1.2.1
-PyYAML==6.0
-qrcode==7.3.1
-requests==2.25.1
-RPi.GPIO==0.7.0
-six==1.16.0
-spidev==3.5
-ssh-import-id==5.10
-urllib3==1.26.5
-viivakoodi==0.8.0
+# Core dependencies (Python 3.13 compatible)
+Pillow>=10.0.0
+python-escpos>=3.0
+pyusb>=1.2.1
+qrcode>=7.3.1
+pyserial>=3.5
+PyYAML>=6.0
+
+# GPIO - use rpi-lgpio for Debian 13 (trixie) compatibility
+rpi-lgpio>=0.6
+
+# Barcode support
+python-barcode>=0.15.0
+
+# Optional dependencies
+appdirs>=1.4.4
+argcomplete>=2.0.0
+six>=1.16.0


### PR DESCRIPTION
## 요약
- AI 에이전트(Claude Code 등)가 자동으로 라즈베리파이 설치를 수행할 수 있는 가이드 추가
- Debian 13 (trixie) / Python 3.13 호환성 문제 해결

## 변경 사항
- **install.md**: AI 에이전트용 단계별 설치 가이드 생성
- **requirements.txt**: Python 3.13 호환 버전으로 업데이트
- **README.md**: AI 에이전트 자동 설치 방법 추가

## 해결된 이슈
- Pillow 9.1.1 빌드 실패 (Python 3.13)
- systemd 서비스에서 Python 모듈 못 찾는 문제
- RPi.GPIO edge detection 실패 → rpi-lgpio로 해결

Fixes #6

## 테스트
- Raspberry Pi + Debian 13 (trixie) 64-bit에서 설치 및 프린트 테스트 완료

🤖 Generated with [Claude Code](https://claude.ai/code)